### PR TITLE
Drop ruby 2.2

### DIFF
--- a/pixela.gemspec
+++ b/pixela.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_curl"
   spec.add_dependency "faraday_middleware"


### PR DESCRIPTION
Ruby 2.2 is already EOL.

https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/