### PR TITLE
Revert "Workaround for error in rspec-parameterized-table_syntax"

### DIFF
--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -7,7 +7,3 @@ if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.7.0")
   # term-ansicolor 1.9.0+ doesn't work on Ruby < 2.7
   gem "term-ansicolor", "< 1.9.0"
 end
-
-# FIXME: Workaround for Ruby 4.0+
-# ref. https://github.com/banister/binding_of_caller/pull/90
-gem "binding_of_caller", github: "kivikakk/binding_of_caller", branch: "push-yrnnzolypxun"


### PR DESCRIPTION
This reverts commit dbde3091aa09a78dcb0d39715bba97992bd1dfa6.